### PR TITLE
feature:  사용자가 지정한 카테고리별로 기술 블로그  보여주기

### DIFF
--- a/component/src/stories/listbox/Listbox.tsx
+++ b/component/src/stories/listbox/Listbox.tsx
@@ -2,7 +2,6 @@ import ListboxItem from './ListboxItem';
 import { IListBoxProps } from './type';
 
 export default function ListBox({ items, onCategoryId, onFilterItems }: IListBoxProps) {
-    console.log(onCategoryId);
     return (
         <>
             {onCategoryId === 0 ? (

--- a/component/src/stories/listbox/Listbox.tsx
+++ b/component/src/stories/listbox/Listbox.tsx
@@ -1,19 +1,23 @@
 import ListboxItem from './ListboxItem';
 import { IListBoxProps } from './type';
 
-export default function ListBox({ items }: IListBoxProps) {
+export default function ListBox({ items, onCategoryId, onFilterItems }: IListBoxProps) {
+    console.log(onCategoryId);
     return (
         <>
-            <div className="flex flex-col w-full gap-6">
-                {items.map((item: any) => (
-                    <ListboxItem
-                        key={item.id}
-                        item={item}
-
-                        //onSetObservationTarget={onSetObservationTarget}
-                    />
-                ))}
-            </div>
+            {onCategoryId === 0 ? (
+                <div className="flex flex-col w-full gap-6">
+                    {items.map((item: any) => (
+                        <ListboxItem key={item.id} item={item} />
+                    ))}
+                </div>
+            ) : (
+                <div className="flex flex-col w-full gap-6">
+                    {onFilterItems.map((item: any) => (
+                        <ListboxItem key={item.id} item={item} />
+                    ))}
+                </div>
+            )}
         </>
     );
 }

--- a/component/src/stories/listbox/Listbox.tsx
+++ b/component/src/stories/listbox/Listbox.tsx
@@ -1,18 +1,15 @@
 import ListboxItem from './ListboxItem';
-import { Props } from './type';
+import { IListBoxProps } from './type';
 
-export default function ListBox({ items }: Props) {
+export default function ListBox({ items, onSetObservationTarget }: IListBoxProps) {
     return (
         <>
-            <div className="flex flex-col gap-6">
-                {items.map(item => (
+            <div className="flex flex-col w-full gap-6">
+                {items.map((item: any) => (
                     <ListboxItem
                         key={item.id}
-                        id={item.id}
-                        title={item.title}
-                        content={item.content}
-                        bookmark={item.bookmark}
-                        views={item.views}
+                        item={item}
+                        onSetObservationTarget={onSetObservationTarget}
                     />
                 ))}
             </div>

--- a/component/src/stories/listbox/Listbox.tsx
+++ b/component/src/stories/listbox/Listbox.tsx
@@ -1,7 +1,7 @@
 import ListboxItem from './ListboxItem';
 import { IListBoxProps } from './type';
 
-export default function ListBox({ items, onSetObservationTarget }: IListBoxProps) {
+export default function ListBox({ items }: IListBoxProps) {
     return (
         <>
             <div className="flex flex-col w-full gap-6">
@@ -9,7 +9,8 @@ export default function ListBox({ items, onSetObservationTarget }: IListBoxProps
                     <ListboxItem
                         key={item.id}
                         item={item}
-                        onSetObservationTarget={onSetObservationTarget}
+
+                        //onSetObservationTarget={onSetObservationTarget}
                     />
                 ))}
             </div>

--- a/component/src/stories/listbox/ListboxItem.tsx
+++ b/component/src/stories/listbox/ListboxItem.tsx
@@ -35,7 +35,6 @@ export default function ListboxItem({ item }: ItemProps) {
                     </span>
                 </div>
             </div>
-            {/* <div ref={onSetObservationTarget}></div> */}
         </>
     );
 }

--- a/component/src/stories/listbox/ListboxItem.tsx
+++ b/component/src/stories/listbox/ListboxItem.tsx
@@ -1,6 +1,6 @@
 import { ItemProps } from './type';
 
-export default function ListboxItem({ item, onSetObservationTarget }: ItemProps) {
+export default function ListboxItem({ item }: ItemProps) {
     return (
         <>
             <div
@@ -35,7 +35,7 @@ export default function ListboxItem({ item, onSetObservationTarget }: ItemProps)
                     </span>
                 </div>
             </div>
-            <div ref={onSetObservationTarget}></div>
+            {/* <div ref={onSetObservationTarget}></div> */}
         </>
     );
 }

--- a/component/src/stories/listbox/ListboxItem.tsx
+++ b/component/src/stories/listbox/ListboxItem.tsx
@@ -5,7 +5,7 @@ export default function ListboxItem({ item }: ItemProps) {
         <>
             <div
                 key={item.techBlogPostBasicInfoDto.id}
-                className="relative flex flex-col justify-around w-10/12 gap-3 pl-6 text-black bg-white rounded-lg h-44"
+                className="relative flex flex-col justify-around w-10/12 gap-3 pl-6 text-black bg-white rounded-lg h-60"
             >
                 <h1 className="text-base font-bold bold">{item.techBlogPostBasicInfoDto.title}</h1>
                 <p className="w-10/12 text-xs">{item.techBlogPostBasicInfoDto.summary}</p>

--- a/component/src/stories/listbox/ListboxItem.tsx
+++ b/component/src/stories/listbox/ListboxItem.tsx
@@ -1,19 +1,41 @@
 import { ItemProps } from './type';
 
-export default function ListboxItem({ id, title, content, bookmark, views }: ItemProps) {
+export default function ListboxItem({ item, onSetObservationTarget }: ItemProps) {
     return (
-        <div
-            key={id}
-            className="flex flex-col justify-around w-10/12 gap-3 pl-6 text-black bg-white rounded-lg h-44"
-        >
-            <h1 className="text-base font-bold bold">{title}</h1>
-            <p className="w-10/12 text-xs">{content}</p>
-            <div className="flex justify-between w-2/12">
-                <span className="flex items-center justify-around text-xs text-center">
-                    좋아요: {bookmark}
-                </span>
-                <span className="text-xs">조회수: {views}</span>
+        <>
+            <div
+                key={item.techBlogPostBasicInfoDto.id}
+                className="relative flex flex-col justify-around w-10/12 gap-3 pl-6 text-black bg-white rounded-lg h-44"
+            >
+                <h1 className="text-base font-bold bold">{item.techBlogPostBasicInfoDto.title}</h1>
+                <p className="w-10/12 text-xs">{item.techBlogPostBasicInfoDto.summary}</p>
+                <ul className="flex gap-4 overflow-hidden">
+                    {item.categoryDto?.map((item: any, index: number) =>
+                        index < 5 ? (
+                            <li key={item.id} id={item.id} className="text-sm">
+                                #{item.name}
+                            </li>
+                        ) : (
+                            <></>
+                        ),
+                    )}
+                    {item.categoryDto?.length > 5 && <li className="text-sm">...</li>}
+                </ul>
+                <img
+                    src={item.techBlogPostBasicInfoDto.thumbnailUrl}
+                    alt="썸네일"
+                    className="absolute flex justify-center w-40 rounded-2xl right-10 h-36"
+                />
+                <div className="flex justify-between w-3/12">
+                    <span className="flex items-center justify-around text-xs text-center">
+                        좋아요: {item.techBlogPostBasicInfoDto.postLike}
+                    </span>
+                    <span className="text-xs">
+                        조회수: {item.techBlogPostBasicInfoDto.viewCount}
+                    </span>
+                </div>
             </div>
-        </div>
+            <div ref={onSetObservationTarget}></div>
+        </>
     );
 }

--- a/component/src/stories/listbox/type.ts
+++ b/component/src/stories/listbox/type.ts
@@ -1,17 +1,9 @@
-export interface Props {
-    items: {
-        id: number;
-        title: string;
-        content: string;
-        bookmark: number;
-        views: number;
-    }[];
+export interface IListBoxProps {
+    items: any;
+    onSetObservationTarget: any;
 }
 
 export interface ItemProps {
-    id: number;
-    title: string;
-    content: string;
-    bookmark: number;
-    views: number;
+    item: any;
+    onSetObservationTarget: any;
 }

--- a/component/src/stories/listbox/type.ts
+++ b/component/src/stories/listbox/type.ts
@@ -1,5 +1,7 @@
 export interface IListBoxProps {
     items: any;
+    onCategoryId: number;
+    onFilterItems: any;
 }
 
 export interface ItemProps {

--- a/component/src/stories/listbox/type.ts
+++ b/component/src/stories/listbox/type.ts
@@ -1,9 +1,7 @@
 export interface IListBoxProps {
     items: any;
-    onSetObservationTarget: any;
 }
 
 export interface ItemProps {
     item: any;
-    onSetObservationTarget: any;
 }

--- a/service/src/components/aside/Aside.tsx
+++ b/service/src/components/aside/Aside.tsx
@@ -47,7 +47,7 @@ const mocks = [
 
 export default function Aside() {
     return (
-        <div className="flex flex-col justify-around w-full p-4 className">
+        <div className="flex flex-col justify-around w-full p-4 my-10">
             <div className="mb-4">
                 <h2 className="my-2 text-lg font-bold">추천 게시글</h2>
                 <Carousel data={mocks} />

--- a/service/src/components/aside/TopKeywords.tsx
+++ b/service/src/components/aside/TopKeywords.tsx
@@ -19,16 +19,15 @@ export default function TopKeywords() {
             getTopkeyDatas();
         }
     }, [didMount]);
-    console.log(topkeywordsData);
     return (
-        <div className="flex flex-col mt-5 ">
+        <div className="flex flex-col mt-5">
             <h3 aria-label="top keyword">Top Keywords</h3>
             <div className="flex items-center w-full flex-warp">
                 <ul className="flex flex-wrap justify-around gap-4 mt-3 ">
                     {topkeywordsData?.map(topkeyword => (
                         <li
                             key={topkeyword.id}
-                            className="gap-4 bg-[#E6F1FE] text-[#006FEE] px-4 py-1.5 rounded-2xl flex-1 text-center text-base"
+                            className="gap-4 bg-[#E6F1FE] text-[#006FEE] px-4 py-1.5 rounded-2xl flex-1 text-center text-base my-2"
                             aria-label="top keyword item"
                         >
                             {topkeyword.name}

--- a/service/src/components/aside/TopPost.tsx
+++ b/service/src/components/aside/TopPost.tsx
@@ -16,7 +16,7 @@ const TopPost = () => {
     return (
         <div className="my-8" aria-label="탑 게시글">
             <h2 className="text-lg font-bold">Top {topContent.length}</h2>
-            <ol className="flex flex-col">
+            <ol className="flex flex-col mt-4">
                 {topContent?.map((content, index) => (
                     <Link
                         to={`/category/detail/${content.id}`}

--- a/service/src/components/card/CardComponent.tsx
+++ b/service/src/components/card/CardComponent.tsx
@@ -11,24 +11,25 @@ export default function CardComponent({ item }: ICardItemsProps) {
         <>
             <Card
                 sx={{
-                    maxWidth: 350,
+                    maxWidth: 380,
+                    minWidth: 380,
                     marginTop: '15px',
-                    //height: '20rem',
                     display: 'flex',
                     flexDirection: 'column',
-                    justifyContent: 'space-around',
+                    justifyContent: 'space-between',
+                    minHeight: 350,
+                    maxHeight: 350,
                 }}
                 key={item.techBlogPostBasicInfoDto.id}
             >
                 <CardActionArea>
                     <CardMedia
                         component="img"
-                        width="286"
-                        //height="100"
+                        width="400"
                         //item.techBlogPostBasicInfoDto.thumbnailUrl
                         image={kakao}
                         alt="썸네일"
-                        style={{ height: '200px' }}
+                        style={{ height: '250px' }}
                     />
                     <CardContent>
                         <Typography gutterBottom variant="h5" component="div">

--- a/service/src/components/card/CardComponent.tsx
+++ b/service/src/components/card/CardComponent.tsx
@@ -5,31 +5,63 @@ import Typography from '@mui/material/Typography';
 import { CardActionArea } from '@mui/material';
 import { ICardItemsProps } from './type';
 
-export default function CardComponent({ items }: ICardItemsProps) {
+export default function CardComponent({ item, onSetObservationTarget }: ICardItemsProps) {
+    const data = '1231321313213213212132155555555555555555';
     return (
         <>
-            {items.map(item => (
-                <>
-                    <Card sx={{ maxWidth: 345 }} key={item.id}>
-                        <CardActionArea>
-                            <CardMedia
-                                component="img"
-                                height="140"
-                                image={item.thumbnailUrl}
-                                alt="썸네일"
-                            />
-                            <CardContent>
-                                <Typography gutterBottom variant="h5" component="div">
-                                    {item.title}
-                                </Typography>
-                                <Typography variant="body2" color="text.secondary">
-                                    {item.content}
-                                </Typography>
-                            </CardContent>
-                        </CardActionArea>
-                    </Card>
-                </>
-            ))}
+            <Card
+                sx={{
+                    width: '35%',
+                    marginTop: '15px',
+                    height: '20rem',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'space-around',
+                }}
+                key={item.techBlogPostBasicInfoDto.id}
+            >
+                <CardActionArea>
+                    <CardMedia
+                        component="img"
+                        height="162"
+                        width="286"
+                        image={item.techBlogPostBasicInfoDto.thumbnailUrl}
+                        alt="썸네일"
+                    />
+                    <CardContent>
+                        <Typography gutterBottom variant="h5" component="div">
+                            {item.techBlogPostBasicInfoDto.title}
+                        </Typography>
+                        <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{ width: '50%', display: 'flex', flexWrap: 'wrap' }}
+                        >
+                            {/* {item.techBlogPostBasicInfoDto.summary} */}
+                            {data.length > 20 && <p>{data}...</p>}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            {item.categoryDto?.map((item: any, index: number) =>
+                                index < 3 ? (
+                                    <span key={item.id} id={item.id} className="mr-2 text-xs">
+                                        #{item.name}
+                                    </span>
+                                ) : (
+                                    <></>
+                                ),
+                            )}
+                            {item.categoryDto?.length > 3 && <span className="text-sm">...</span>}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            <span className="mr-2 text-xs">
+                                좋아요: {item.techBlogPostBasicInfoDto.postLike}
+                            </span>
+                            <span>조회수: {item.techBlogPostBasicInfoDto.viewCount}</span>
+                        </Typography>
+                    </CardContent>
+                </CardActionArea>
+            </Card>
+            <div ref={onSetObservationTarget}></div>
         </>
     );
 }

--- a/service/src/components/card/CardComponent.tsx
+++ b/service/src/components/card/CardComponent.tsx
@@ -4,16 +4,16 @@ import CardMedia from '@mui/material/CardMedia';
 import Typography from '@mui/material/Typography';
 import { CardActionArea } from '@mui/material';
 import { ICardItemsProps } from './type';
+import kakao from '@monorepo/service/src/assets/kakao.webp';
 
-export default function CardComponent({ item, onSetObservationTarget }: ICardItemsProps) {
-    const data = '1231321313213213212132155555555555555555';
+export default function CardComponent({ item }: ICardItemsProps) {
     return (
         <>
             <Card
                 sx={{
-                    width: '35%',
+                    maxWidth: 350,
                     marginTop: '15px',
-                    height: '20rem',
+                    //height: '20rem',
                     display: 'flex',
                     flexDirection: 'column',
                     justifyContent: 'space-around',
@@ -23,10 +23,12 @@ export default function CardComponent({ item, onSetObservationTarget }: ICardIte
                 <CardActionArea>
                     <CardMedia
                         component="img"
-                        height="162"
                         width="286"
-                        image={item.techBlogPostBasicInfoDto.thumbnailUrl}
+                        //height="100"
+                        //item.techBlogPostBasicInfoDto.thumbnailUrl
+                        image={kakao}
                         alt="썸네일"
+                        style={{ height: '200px' }}
                     />
                     <CardContent>
                         <Typography gutterBottom variant="h5" component="div">
@@ -37,8 +39,7 @@ export default function CardComponent({ item, onSetObservationTarget }: ICardIte
                             color="text.secondary"
                             sx={{ width: '50%', display: 'flex', flexWrap: 'wrap' }}
                         >
-                            {/* {item.techBlogPostBasicInfoDto.summary} */}
-                            {data.length > 20 && <p>{data}...</p>}
+                            {item.techBlogPostBasicInfoDto.summary}
                         </Typography>
                         <Typography variant="body2" color="text.secondary">
                             {item.categoryDto?.map((item: any, index: number) =>
@@ -61,7 +62,6 @@ export default function CardComponent({ item, onSetObservationTarget }: ICardIte
                     </CardContent>
                 </CardActionArea>
             </Card>
-            <div ref={onSetObservationTarget}></div>
         </>
     );
 }

--- a/service/src/components/card/CardList.tsx
+++ b/service/src/components/card/CardList.tsx
@@ -6,11 +6,7 @@ export default function CardList({ items }: IListBoxProps) {
         <>
             <div className="flex flex-wrap justify-between gap-6">
                 {items.map((item: any) => (
-                    <CardComponent
-                        key={item.id}
-                        item={item}
-                        //onSetObservationTarget={onSetObservationTarget}
-                    />
+                    <CardComponent key={item.id} item={item} />
                 ))}
             </div>
         </>

--- a/service/src/components/card/CardList.tsx
+++ b/service/src/components/card/CardList.tsx
@@ -1,14 +1,22 @@
 import CardComponent from './CardComponent';
 import { IListBoxProps } from '@monorepo/component/src/stories/listbox/type';
 
-export default function CardList({ items }: IListBoxProps) {
+export default function CardList({ items, onCategoryId, onFilterItems }: IListBoxProps) {
     return (
         <>
-            <div className="flex flex-wrap justify-between gap-6">
-                {items.map((item: any) => (
-                    <CardComponent key={item.id} item={item} />
-                ))}
-            </div>
+            {onCategoryId === 0 ? (
+                <div className="flex flex-wrap justify-between w-10/12">
+                    {items.map((item: any) => (
+                        <CardComponent key={item.id} item={item} />
+                    ))}
+                </div>
+            ) : (
+                <div className="flex flex-wrap justify-between w-10/12">
+                    {onFilterItems.map((item: any) => (
+                        <CardComponent key={item.id} item={item} />
+                    ))}
+                </div>
+            )}
         </>
     );
 }

--- a/service/src/components/card/CardList.tsx
+++ b/service/src/components/card/CardList.tsx
@@ -1,7 +1,7 @@
 import CardComponent from './CardComponent';
 import { IListBoxProps } from '@monorepo/component/src/stories/listbox/type';
 
-export default function CardList({ items, onSetObservationTarget }: IListBoxProps) {
+export default function CardList({ items }: IListBoxProps) {
     return (
         <>
             <div className="flex flex-wrap justify-between gap-6">
@@ -9,7 +9,7 @@ export default function CardList({ items, onSetObservationTarget }: IListBoxProp
                     <CardComponent
                         key={item.id}
                         item={item}
-                        onSetObservationTarget={onSetObservationTarget}
+                        //onSetObservationTarget={onSetObservationTarget}
                     />
                 ))}
             </div>

--- a/service/src/components/card/CardList.tsx
+++ b/service/src/components/card/CardList.tsx
@@ -1,66 +1,18 @@
 import CardComponent from './CardComponent';
+import { IListBoxProps } from '@monorepo/component/src/stories/listbox/type';
 
-const items = [
-    {
-        id: 1,
-        title: '우아한형제들 PM의 이야기- “배민 기획자의 일”',
-        content:
-            '우아한형제들 PM(Product Manager)는 어떻게 일할까? 실제 이야기를 담은 책 "배민 기획자의 일"  PM들과 함께 나눈 이야기를 담았습니다.',
-        bookmark: 1000,
-        views: 50000,
-        thumbnailUrl: '',
-    },
-    {
-        id: 1,
-        title: '우아한형제들 PM의 이야기- “배민 기획자의 일”',
-        content:
-            '우아한형제들 PM(Product Manager)는 어떻게 일할까? 실제 이야기를 담은 책 "배민 기획자의 일"  PM들과 함께 나눈 이야기를 담았습니다.',
-        bookmark: 1000,
-        views: 50000,
-        thumbnailUrl: '',
-    },
-    {
-        id: 1,
-        title: '우아한형제들 PM의 이야기- “배민 기획자의 일”',
-        content:
-            '우아한형제들 PM(Product Manager)는 어떻게 일할까? 실제 이야기를 담은 책 "배민 기획자의 일"  PM들과 함께 나눈 이야기를 담았습니다.',
-        bookmark: 1000,
-        views: 50000,
-        thumbnailUrl: '',
-    },
-    {
-        id: 1,
-        title: '우아한형제들 PM의 이야기- “배민 기획자의 일”',
-        content:
-            '우아한형제들 PM(Product Manager)는 어떻게 일할까? 실제 이야기를 담은 책 "배민 기획자의 일"  PM들과 함께 나눈 이야기를 담았습니다.',
-        bookmark: 1000,
-        views: 50000,
-        thumbnailUrl: '',
-    },
-    {
-        id: 1,
-        title: '우아한형제들 PM의 이야기- “배민 기획자의 일”',
-        content:
-            '우아한형제들 PM(Product Manager)는 어떻게 일할까? 실제 이야기를 담은 책 "배민 기획자의 일"  PM들과 함께 나눈 이야기를 담았습니다.',
-        bookmark: 1000,
-        views: 50000,
-        thumbnailUrl: '',
-    },
-    {
-        id: 1,
-        title: '우아한형제들 PM의 이야기- “배민 기획자의 일”',
-        content:
-            '우아한형제들 PM(Product Manager)는 어떻게 일할까? 실제 이야기를 담은 책 "배민 기획자의 일"  PM들과 함께 나눈 이야기를 담았습니다.',
-        bookmark: 1000,
-        views: 50000,
-        thumbnailUrl: '',
-    },
-];
-
-export default function CardList() {
+export default function CardList({ items, onSetObservationTarget }: IListBoxProps) {
     return (
         <>
-            <CardComponent items={items} />
+            <div className="flex flex-wrap justify-between gap-6">
+                {items.map((item: any) => (
+                    <CardComponent
+                        key={item.id}
+                        item={item}
+                        onSetObservationTarget={onSetObservationTarget}
+                    />
+                ))}
+            </div>
         </>
     );
 }

--- a/service/src/components/card/type.ts
+++ b/service/src/components/card/type.ts
@@ -1,10 +1,4 @@
 export interface ICardItemsProps {
-    items: {
-        id: number;
-        title: string;
-        content: string;
-        bookmark: number;
-        views: number;
-        thumbnailUrl: string;
-    }[];
+    item: any;
+    onSetObservationTarget: any;
 }

--- a/service/src/components/card/type.ts
+++ b/service/src/components/card/type.ts
@@ -1,4 +1,4 @@
 export interface ICardItemsProps {
     item: any;
-    onSetObservationTarget: any;
+    //onSetObservationTarget: any;
 }

--- a/service/src/components/carousel/CategorySlide.tsx
+++ b/service/src/components/carousel/CategorySlide.tsx
@@ -17,6 +17,9 @@ interface CarouselProps {
     onSetCategoryId: React.Dispatch<SetStateAction<number>>;
     onCategoryId: number;
     onUserTechBlogRender: () => void;
+    onSetPage: React.Dispatch<SetStateAction<number>>;
+    onSetObservationTarget: any;
+    onSetFilterTechBlogData: any;
 }
 
 export default function CategorySlide({
@@ -29,9 +32,11 @@ export default function CategorySlide({
     onSetCategoryId,
     onCategoryId,
     onUserTechBlogRender,
+    onSetPage,
+    onSetObservationTarget,
+    onSetFilterTechBlogData,
 }: CarouselProps) {
     const [current, setCurrent] = useState(0);
-
     const scrollRef = useRef<HTMLDivElement | null>(null);
     const prevSlider = () => {
         setCurrent(current === 0 ? items.length - 1 : current - 1);
@@ -45,12 +50,18 @@ export default function CategorySlide({
         if (Number(numberId !== 0)) {
             onUserFilterTechBlogRender(id);
             onSetCategoryId(numberId);
+            onSetPage(0);
+            onSetFilterTechBlogData([]);
         } else {
             onUserTechBlogRender();
+            onSetCategoryId(numberId);
+            onSetPage(0);
+            onSetFilterTechBlogData([]);
         }
     };
 
     const ALLCATEGORYNUM = '0';
+
     return (
         <>
             <div>
@@ -58,38 +69,40 @@ export default function CategorySlide({
             </div>
 
             <div
-                className={`relative flex rounded-md will-change-transform flex-1 items-center text-center gap-4`}
+                className={`relative flex rounded-md will-change-transform flex-1 items-center text-center gap-4 w-full`}
                 ref={scrollRef}
                 aria-label="추천 게시글"
             >
                 <div
-                    className={` transition ease-out duration-400 absolute flex justify-center items-center overflow-hidden w-full`}
+                    className={` transition ease-out duration-400 absolute flex justify-center items-center overflow-hidden w-full  `}
                 >
                     <div
                         style={{ transform: `translateX(${current * 10}%)` }}
-                        className="flex items-center w-full overflow-hidden"
+                        className="flex items-center w-full"
                     >
                         <Button
-                            className="text-[#006FEE] w-14 h-7 text-center text-xs flex items-center justify-center"
+                            className="text-[#006FEE] w-14 h-7 text-center text-xs flex items-center justify-start"
                             onClick={onHandleModalOpen}
                             role="Button"
                             aria-label="카테고리추가 버튼"
                         >
                             <AddIcon />
                         </Button>
-                        <Button
-                            id={ALLCATEGORYNUM}
-                            className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg text-center items-center flex-1 ${
-                                Number(ALLCATEGORYNUM) === onCategoryId
-                                    ? 'bg-red-500'
-                                    : 'bg-[#E6F1FE]'
-                            } `}
-                            role="Button"
-                            aria-label="카테고리추가 버튼"
-                            onClick={(e: any) => handleUserCategoryId(e.target.id)}
-                        >
-                            전체 게시글
-                        </Button>
+                        <div className={`relative flex dark-box-bg pl-2 pr-2 text-center `}>
+                            <Button
+                                id={ALLCATEGORYNUM}
+                                className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg  items-center w-20 text-center ${
+                                    Number(ALLCATEGORYNUM) === onCategoryId
+                                        ? 'bg-[#006FEE] text-white'
+                                        : 'bg-[#E6F1FE]'
+                                } `}
+                                role="Button"
+                                aria-label="카테고리추가 버튼"
+                                onClick={(e: any) => handleUserCategoryId(e.target.id)}
+                            >
+                                For You
+                            </Button>
+                        </div>
                         {items?.map((item: any) => (
                             <div
                                 key={item.id}
@@ -98,7 +111,9 @@ export default function CategorySlide({
                             >
                                 <Button
                                     className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg text-center items-center flex-1 ${
-                                        item.id === onCategoryId ? 'bg-red-500' : 'bg-[#E6F1FE]'
+                                        item.id === onCategoryId
+                                            ? 'bg-[#006FEE] text-white'
+                                            : 'bg-[#E6F1FE]'
                                     } `}
                                     id={item.id}
                                     role="Button"
@@ -111,8 +126,9 @@ export default function CategorySlide({
                         ))}
                     </div>
                 </div>
+                <div ref={onSetObservationTarget}></div>
             </div>
-            <div className="flex justify-end">
+            <div className="flex justify-end mr-10">
                 <RiArrowDropRightLine
                     onClick={nextSlider}
                     size={40}

--- a/service/src/components/carousel/CategorySlide.tsx
+++ b/service/src/components/carousel/CategorySlide.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, SetStateAction } from 'react';
 import { RiArrowDropLeftLine, RiArrowDropRightLine } from 'react-icons/ri';
 import { Button } from '@mui/base/Button';
 import AddIcon from '@mui/icons-material/Add';
@@ -13,6 +13,10 @@ interface CarouselProps {
     onClose: () => void;
     onHandleModalOpen?: () => void;
     userGetCategoryRender: () => void;
+    onUserFilterTechBlogRender: any;
+    onSetCategoryId: React.Dispatch<SetStateAction<number>>;
+    onCategoryId: number;
+    onUserTechBlogRender: () => void;
 }
 
 export default function CategorySlide({
@@ -21,11 +25,14 @@ export default function CategorySlide({
     onModalOpen,
     onClose,
     userGetCategoryRender,
+    onUserFilterTechBlogRender,
+    onSetCategoryId,
+    onCategoryId,
+    onUserTechBlogRender,
 }: CarouselProps) {
     const [current, setCurrent] = useState(0);
 
     const scrollRef = useRef<HTMLDivElement | null>(null);
-
     const prevSlider = () => {
         setCurrent(current === 0 ? items.length - 1 : current - 1);
     };
@@ -33,19 +40,23 @@ export default function CategorySlide({
         setCurrent(current === items.length - 1 ? 0 : current + 1);
     };
 
+    const handleUserCategoryId = (id: string) => {
+        const numberId = parseInt(id, 10);
+        if (Number(numberId !== 0)) {
+            onUserFilterTechBlogRender(id);
+            onSetCategoryId(numberId);
+        } else {
+            onUserTechBlogRender();
+        }
+    };
+
+    const ALLCATEGORYNUM = '0';
     return (
         <>
             <div>
                 <RiArrowDropLeftLine onClick={prevSlider} size={40} aria-label="왼쪽으로 넘기기" />
             </div>
-            <Button
-                className="text-[#006FEE] w-14 h-7 text-center text-xs flex items-center justify-center"
-                onClick={onHandleModalOpen}
-                role="Button"
-                aria-label="카테고리추가 버튼"
-            >
-                <AddIcon />
-            </Button>
+
             <div
                 className={`relative flex rounded-md will-change-transform flex-1 items-center text-center gap-4`}
                 ref={scrollRef}
@@ -54,24 +65,51 @@ export default function CategorySlide({
                 <div
                     className={` transition ease-out duration-400 absolute flex justify-center items-center overflow-hidden w-full`}
                 >
-                    {items?.map((item: any) => (
-                        <div
-                            key={item.id}
-                            id={item.id}
-                            style={{ transform: `translateX(${current * 50}%)` }}
-                            className={`relative flex dark-box-bg pl-2 pr-2 text-center`}
-                            aria-label="선호 카테고리 영역"
+                    <div
+                        style={{ transform: `translateX(${current * 10}%)` }}
+                        className="flex items-center w-full overflow-hidden"
+                    >
+                        <Button
+                            className="text-[#006FEE] w-14 h-7 text-center text-xs flex items-center justify-center"
+                            onClick={onHandleModalOpen}
+                            role="Button"
+                            aria-label="카테고리추가 버튼"
                         >
-                            <Button
-                                className="flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg text-center items-center flex-1"
-                                id={item.id}
-                                role="Button"
-                                aria-label="카테고리"
+                            <AddIcon />
+                        </Button>
+                        <Button
+                            id={ALLCATEGORYNUM}
+                            className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg text-center items-center flex-1 ${
+                                Number(ALLCATEGORYNUM) === onCategoryId
+                                    ? 'bg-red-500'
+                                    : 'bg-[#E6F1FE]'
+                            } `}
+                            role="Button"
+                            aria-label="카테고리추가 버튼"
+                            onClick={(e: any) => handleUserCategoryId(e.target.id)}
+                        >
+                            전체 게시글
+                        </Button>
+                        {items?.map((item: any) => (
+                            <div
+                                key={item.id}
+                                className={`relative flex dark-box-bg pl-2 pr-2 text-center`}
+                                aria-label="선호 카테고리 영역"
                             >
-                                {item.name}
-                            </Button>
-                        </div>
-                    ))}
+                                <Button
+                                    className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg text-center items-center flex-1 ${
+                                        item.id === onCategoryId ? 'bg-red-500' : 'bg-[#E6F1FE]'
+                                    } `}
+                                    id={item.id}
+                                    role="Button"
+                                    aria-label="카테고리"
+                                    onClick={(e: any) => handleUserCategoryId(e.target.id)}
+                                >
+                                    {item.name}
+                                </Button>
+                            </div>
+                        ))}
+                    </div>
                 </div>
             </div>
             <div className="flex justify-end">

--- a/service/src/components/carousel/CategorySlide.tsx
+++ b/service/src/components/carousel/CategorySlide.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, SetStateAction } from 'react';
+import { useRef, useState, SetStateAction } from 'react';
 import { RiArrowDropLeftLine, RiArrowDropRightLine } from 'react-icons/ri';
 import { Button } from '@mui/base/Button';
 import AddIcon from '@mui/icons-material/Add';
@@ -61,25 +61,27 @@ export default function CategorySlide({
     };
 
     const ALLCATEGORYNUM = '0';
-
     return (
         <>
             <div>
-                <RiArrowDropLeftLine onClick={prevSlider} size={40} aria-label="왼쪽으로 넘기기" />
+                {current !== 0 && (
+                    <RiArrowDropLeftLine
+                        onClick={prevSlider}
+                        size={40}
+                        aria-label="왼쪽으로 넘기기"
+                    />
+                )}
             </div>
-
             <div
-                className={`relative flex rounded-md will-change-transform flex-1 items-center text-center gap-4 w-full`}
+                className={`relative flex w-full overflow-hidden justify-between items-center`}
                 ref={scrollRef}
-                aria-label="추천 게시글"
+                aria-label="선호 카테고리"
             >
                 <div
-                    className={` transition ease-out duration-400 absolute flex justify-center items-center overflow-hidden w-full  `}
+                    className={` transition ease-out duration-400 absolute flex justify-center items-center`}
+                    style={{ transform: `translate3d(-${current * 30}px,0px,0px)` }}
                 >
-                    <div
-                        style={{ transform: `translateX(${current * 10}%)` }}
-                        className="flex items-center w-full"
-                    >
+                    <div className="flex items-center w-full">
                         <Button
                             className="text-[#006FEE] w-14 h-7 text-center text-xs flex items-center justify-start"
                             onClick={onHandleModalOpen}
@@ -91,9 +93,9 @@ export default function CategorySlide({
                         <div className={`relative flex dark-box-bg pl-2 pr-2 text-center `}>
                             <Button
                                 id={ALLCATEGORYNUM}
-                                className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg  items-center w-20 text-center ${
+                                className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg  items-center w-20 text-center justify-center ${
                                     Number(ALLCATEGORYNUM) === onCategoryId
-                                        ? 'bg-[#006FEE] text-white'
+                                        ? 'bg-[#005FEE] text-white'
                                         : 'bg-[#E6F1FE]'
                                 } `}
                                 role="Button"
@@ -106,13 +108,13 @@ export default function CategorySlide({
                         {items?.map((item: any) => (
                             <div
                                 key={item.id}
-                                className={`relative flex dark-box-bg pl-2 pr-2 text-center`}
+                                className={`flex dark-box-bg pl-2 pr-2 text-center transition ease-out duration-400 justify-center items-center`}
                                 aria-label="선호 카테고리 영역"
                             >
                                 <Button
                                     className={`flex bg-[#E6F1FE] text-[#006FEE] p-1 rounded-lg text-center items-center flex-1 ${
                                         item.id === onCategoryId
-                                            ? 'bg-[#006FEE] text-white'
+                                            ? 'bg-[#005FEE] text-white'
                                             : 'bg-[#E6F1FE]'
                                     } `}
                                     id={item.id}
@@ -126,15 +128,14 @@ export default function CategorySlide({
                         ))}
                     </div>
                 </div>
-                <div ref={onSetObservationTarget}></div>
             </div>
-            <div className="flex justify-end mr-10">
-                <RiArrowDropRightLine
-                    onClick={nextSlider}
-                    size={40}
-                    aria-label="오른쪽으로 넘기기"
-                />
-            </div>
+            <RiArrowDropRightLine
+                onClick={nextSlider}
+                size={40}
+                aria-label="오른쪽으로 넘기기"
+                // className="absolute"
+            />
+            {/* <div ref={onSetObservationTarget}></div> */}
             <UserCategoryModal
                 onClose={onClose}
                 onModalOpen={onModalOpen}

--- a/service/src/components/layout/Layout.tsx
+++ b/service/src/components/layout/Layout.tsx
@@ -1,18 +1,24 @@
 import { Outlet } from 'react-router-dom';
 
 import Header from '@monorepo/component/src/stories/header/Header';
+import Aside from '../aside/Aside';
 
 export default function Layout() {
     return (
-        <>
+        <div>
             <Header />
-            <div className="block m-auto mt-5 mx-36">
-                <main>
-                    <section aria-label="메인 콘텐츠">
+            <div className="flex w-full justify-evenly">
+                <main className="flex justify-end w-10/12">
+                    <section aria-label="메인 콘텐츠" className="w-10/12">
                         <Outlet />
                     </section>
                 </main>
+                <aside className="max-w-md pl-2 mr-20 border-l-2 border-solid border-zinc-500">
+                    <div className="w-[100%] inline-block sticky right-0 top-10">
+                        <Aside />
+                    </div>
+                </aside>
             </div>
-        </>
+        </div>
     );
 }

--- a/service/src/components/modal/UserCategoryModal.tsx
+++ b/service/src/components/modal/UserCategoryModal.tsx
@@ -54,7 +54,6 @@ const buttonStyle = {
 };
 
 function UserCategoryModal({ onModalOpen, onClose, userGetCategoryRender }: UserCategoryProps) {
-    const [didMount, setDidmount] = useState(false);
     const [categoryItems, setCategoryItems] = useState<any[]>([]); //전체 카테고리 리스트
     const userCategoryItems = useRecoilValue(userCategoryState); //선호 카테고리
     const [activeCategoriesData, setActiveCategoriesData] = useState<any[]>([]); // 카테고리 선택
@@ -108,14 +107,6 @@ function UserCategoryModal({ onModalOpen, onClose, userGetCategoryRender }: User
     useEffect(() => {
         getCategoryList();
     }, [page]);
-
-    useEffect(() => {
-        setDidmount(true);
-    }, []);
-
-    useEffect(() => {
-        if (didMount) getCategoryList();
-    }, []);
 
     return (
         <>

--- a/service/src/components/modal/UserCategoryModal.tsx
+++ b/service/src/components/modal/UserCategoryModal.tsx
@@ -107,7 +107,6 @@ function UserCategoryModal({ onModalOpen, onClose, userGetCategoryRender }: User
     useEffect(() => {
         getCategoryList();
     }, [page]);
-
     return (
         <>
             <Modal onClose={onClose} open={onModalOpen}>

--- a/service/src/hooks/useIntersectionObserver.tsx
+++ b/service/src/hooks/useIntersectionObserver.tsx
@@ -1,26 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
 
 export const useIntersectionObserver = (callback: () => void) => {
-    const [observationTarget, setObservationTarget] = useState(null);
-    const observer = useRef(
-        new IntersectionObserver(
-            ([entry]) => {
-                if (!entry.isIntersecting) return;
-                callback();
-            },
-            { threshold: 1 },
-        ),
-    );
-
+    const [observationTarget, setObservationTarget] = useState<HTMLDivElement | null>(null);
+    const observer = useRef<IntersectionObserver | null>(null);
     useEffect(() => {
-        const currentTarget = observationTarget;
-        const currentObserver = observer.current;
-        if (currentTarget) {
-            currentObserver.observe(currentTarget);
+        if (observationTarget) {
+            observer.current = new IntersectionObserver(
+                ([entry]) => {
+                    if (!entry.isIntersecting) return;
+                    console.log(callback);
+                    callback();
+                },
+                { threshold: 1 },
+            );
+            observer.current.observe(observationTarget);
         }
         return () => {
-            if (currentTarget) {
-                currentObserver.unobserve(currentTarget);
+            if (observer.current && observationTarget) {
+                observer.current.unobserve(observationTarget);
             }
         };
     }, [observationTarget]);

--- a/service/src/hooks/useTokenDecode.tsx
+++ b/service/src/hooks/useTokenDecode.tsx
@@ -1,16 +1,9 @@
-import { getAuthStorage } from '../repository/AuthRepository';
 import { Base64 } from 'js-base64';
 
-const TOKEN_KEY = 'accessToken';
-
-const token = getAuthStorage(TOKEN_KEY);
-export function useTokenDecode() {
+export function useTokenDecode(token: string | null) {
     if (token) {
         const payload = token.split('.')[1];
         const { id } = JSON.parse(Base64.decode(payload));
         return id;
-    } else {
-        // Handle the case where token is null (you may return a default value or throw an error)
-        throw new Error('Token is null');
     }
 }

--- a/service/src/index.css
+++ b/service/src/index.css
@@ -40,10 +40,6 @@ input:autofill:active {
     -webkit-text-size-adjust: 100%;
 }
 
-/* .abc {
-    background-color: #000;
-} */
-
 a {
     font-weight: 500;
     color: #646cff;
@@ -54,11 +50,11 @@ a:hover {
 }
 
 body {
-    /* margin: 0; */
     display: flex;
     place-items: center;
-    /* min-width: 320px;
-    min-height: 100vh; */
+    overflow-x: hidden;
+    -ms-overflow-style: none; /* IE, Edge */
+    scrollbar-width: none; /* Firefox */
 }
 
 h1 {
@@ -83,10 +79,6 @@ button:hover {
 button:focus,
 button:focus-visible {
     outline: 4px auto -webkit-focus-ring-color;
-}
-
-::-webkit-scrollbar {
-    display: none;
 }
 
 @media (prefers-color-scheme: light) {

--- a/service/src/pages/MainPage.tsx
+++ b/service/src/pages/MainPage.tsx
@@ -12,7 +12,7 @@ import CategorySlide from '../components/carousel/CategorySlide';
 import { userCategoryState } from '../recoil/atom/userCategoryState';
 import { useTokenDecode } from '../hooks/useTokenDecode';
 import { AuthCategoryService } from '../service/CategoryService';
-import { getTechBlogService } from '../service/TechBlogService';
+import { getTechBlogService, getUserTechBlogService } from '../service/TechBlogService';
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
 
 export default function MainPage() {
@@ -20,10 +20,11 @@ export default function MainPage() {
     const [techBlogData, setTechBlogData] = useState<any[]>([]);
     const [displayMode, setDisplayMode] = useState(true);
     const [page, setPage] = useState(0);
+    //const [techCategoryClicked, setTechCategroyClicked] = useState(false);
+    const [categoryId, setCategoryId] = useState(0);
     const [userCategoryItems, setUserCategoryItems] = useRecoilState(userCategoryState); //선호 카테고리
     const [didMount, setDidmount] = useState(false);
-
-    const size = 3;
+    const size = 6;
 
     const sort = 'createdAt';
 
@@ -37,8 +38,19 @@ export default function MainPage() {
     const tokenDecode = useTokenDecode(getToken);
 
     async function userTechBlogRender() {
-        const userCategoryData = await getTechBlogService({ page, size, sort, direction });
-        setTechBlogData(prev => [...prev, ...userCategoryData.content]);
+        const userTechBlogData = await getTechBlogService({ page, size, sort, direction });
+        setTechBlogData(prev => [...prev, ...userTechBlogData.content]);
+    }
+
+    async function userFilterTechBlogRender(id: number) {
+        const userFilterTechBlogData = await getUserTechBlogService({
+            page,
+            size,
+            sort,
+            direction,
+            id,
+        });
+        setTechBlogData(userFilterTechBlogData.content);
     }
 
     async function userGetCategoryRender() {
@@ -60,7 +72,9 @@ export default function MainPage() {
     }, [techBlogData]);
 
     useEffect(() => {
-        userTechBlogRender();
+        if (categoryId === 0) {
+            userTechBlogRender();
+        }
     }, [page]);
 
     useEffect(() => {
@@ -70,7 +84,6 @@ export default function MainPage() {
     useEffect(() => {
         if (didMount) {
             userGetCategoryRender();
-            userTechBlogRender();
         }
     }, [didMount]);
 
@@ -79,6 +92,7 @@ export default function MainPage() {
     }, [isCategoryModalOpen]);
 
     const setObservationTarget = useIntersectionObserver(fetchMoreIssue);
+
     return (
         <div className="flex justify-between">
             <div className="flex flex-col w-10/12 gap-6">
@@ -90,6 +104,10 @@ export default function MainPage() {
                             onModalOpen={isCategoryModalOpen}
                             onHandleModalOpen={handleSignupNext}
                             userGetCategoryRender={userGetCategoryRender}
+                            onUserFilterTechBlogRender={userFilterTechBlogRender}
+                            onSetCategoryId={setCategoryId}
+                            onCategoryId={categoryId}
+                            onUserTechBlogRender={userTechBlogRender}
                         />
                     )}
                 </div>
@@ -109,17 +127,12 @@ export default function MainPage() {
                         </FormGroup>
                     </div>
                     {displayMode ? (
-                        <ListBox
-                            items={techBlogData}
-                            onSetObservationTarget={setObservationTarget}
-                        />
+                        <ListBox items={techBlogData} />
                     ) : (
-                        <CardList
-                            items={techBlogData}
-                            onSetObservationTarget={setObservationTarget}
-                        />
+                        <CardList items={techBlogData} />
                     )}
                 </div>
+                <div ref={setObservationTarget}></div>
             </div>
             <SignUpModal onSignupNext={handleSignupNext} />
         </div>

--- a/service/src/pages/MainPage.tsx
+++ b/service/src/pages/MainPage.tsx
@@ -24,7 +24,7 @@ export default function MainPage() {
     const [categoryId, setCategoryId] = useState(0);
     const [userCategoryItems, setUserCategoryItems] = useRecoilState(userCategoryState); //선호 카테고리
     const [didMount, setDidmount] = useState(false);
-    const size = 6;
+    const size = 10;
 
     const sort = 'createdAt';
 
@@ -93,11 +93,10 @@ export default function MainPage() {
     }, [isCategoryModalOpen]);
 
     const setObservationTarget = useIntersectionObserver(fetchMoreIssue);
-    console.log(userCategoryItems);
     return (
         <div className="flex justify-between">
-            <div className="flex flex-col w-10/12 gap-6">
-                <div className="flex items-center justify-around w-10/12 mt-8 ">
+            <div className="flex flex-col w-full gap-6">
+                <div className="flex max-w-3xl mt-8">
                     {getToken && (
                         <CategorySlide
                             items={userCategoryItems}

--- a/service/src/pages/MainPage.tsx
+++ b/service/src/pages/MainPage.tsx
@@ -18,9 +18,9 @@ import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
 export default function MainPage() {
     const [isCategoryModalOpen, setCategoryModalOpen] = useState(false);
     const [techBlogData, setTechBlogData] = useState<any[]>([]);
+    const [filterTechBlogData, setFilterTechBlogData] = useState<any[]>([]);
     const [displayMode, setDisplayMode] = useState(true);
     const [page, setPage] = useState(0);
-    //const [techCategoryClicked, setTechCategroyClicked] = useState(false);
     const [categoryId, setCategoryId] = useState(0);
     const [userCategoryItems, setUserCategoryItems] = useRecoilState(userCategoryState); //선호 카테고리
     const [didMount, setDidmount] = useState(false);
@@ -50,7 +50,7 @@ export default function MainPage() {
             direction,
             id,
         });
-        setTechBlogData(userFilterTechBlogData.content);
+        setFilterTechBlogData(prev => [...prev, ...userFilterTechBlogData.content]);
     }
 
     async function userGetCategoryRender() {
@@ -75,6 +75,7 @@ export default function MainPage() {
         if (categoryId === 0) {
             userTechBlogRender();
         }
+        userFilterTechBlogRender(categoryId);
     }, [page]);
 
     useEffect(() => {
@@ -92,11 +93,11 @@ export default function MainPage() {
     }, [isCategoryModalOpen]);
 
     const setObservationTarget = useIntersectionObserver(fetchMoreIssue);
-
+    console.log(userCategoryItems);
     return (
         <div className="flex justify-between">
             <div className="flex flex-col w-10/12 gap-6">
-                <div className="flex items-center justify-around w-3/4 mt-5 ">
+                <div className="flex items-center justify-around w-10/12 mt-8 ">
                     {getToken && (
                         <CategorySlide
                             items={userCategoryItems}
@@ -108,6 +109,9 @@ export default function MainPage() {
                             onSetCategoryId={setCategoryId}
                             onCategoryId={categoryId}
                             onUserTechBlogRender={userTechBlogRender}
+                            onSetPage={setPage}
+                            onSetObservationTarget={setObservationTarget}
+                            onSetFilterTechBlogData={setFilterTechBlogData}
                         />
                     )}
                 </div>
@@ -127,9 +131,17 @@ export default function MainPage() {
                         </FormGroup>
                     </div>
                     {displayMode ? (
-                        <ListBox items={techBlogData} />
+                        <ListBox
+                            items={techBlogData}
+                            onCategoryId={categoryId}
+                            onFilterItems={filterTechBlogData}
+                        />
                     ) : (
-                        <CardList items={techBlogData} />
+                        <CardList
+                            items={techBlogData}
+                            onCategoryId={categoryId}
+                            onFilterItems={filterTechBlogData}
+                        />
                     )}
                 </div>
                 <div ref={setObservationTarget}></div>

--- a/service/src/service/TechBlogService.ts
+++ b/service/src/service/TechBlogService.ts
@@ -5,6 +5,7 @@ interface ITechBlogCategory {
     size: number;
     sort: string;
     direction: string;
+    id?: number;
 }
 
 export async function getTechBlogService({ page, size, sort, direction }: ITechBlogCategory) {
@@ -12,7 +13,23 @@ export async function getTechBlogService({ page, size, sort, direction }: ITechB
         const res = await HttpClient.get(
             `/api/v1/posts?page=${page}&size=${size}&sort=${sort}&direction=${direction}`,
         );
-        console.log(res.data);
+        return res.data;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+export async function getUserTechBlogService({
+    page,
+    size,
+    sort,
+    direction,
+    id,
+}: ITechBlogCategory) {
+    try {
+        const res = await HttpClient.get(
+            `/api/v1/posts/category/${id}?page=${page}&size=${size}&sort=${sort}&direction=${direction}`,
+        );
         return res.data;
     } catch (error) {
         console.error(error);

--- a/service/src/service/TechBlogService.ts
+++ b/service/src/service/TechBlogService.ts
@@ -1,0 +1,20 @@
+import HttpClient from '../apis/HttpClient';
+
+interface ITechBlogCategory {
+    page: number;
+    size: number;
+    sort: string;
+    direction: string;
+}
+
+export async function getTechBlogService({ page, size, sort, direction }: ITechBlogCategory) {
+    try {
+        const res = await HttpClient.get(
+            `/api/v1/posts?page=${page}&size=${size}&sort=${sort}&direction=${direction}`,
+        );
+        console.log(res.data);
+        return res.data;
+    } catch (error) {
+        console.error(error);
+    }
+}


### PR DESCRIPTION
전체 게시글의 경우 임의 id 값을 주어 처음 렌더링 시 바로 클릭 되어 있는 것으로 지정하여 사용

각 카테고리 별로 클릭시 이전 게시글의 정보를 담아서 보여주는 현상을 해결하기 위해 id값이 바뀔때마다 기술 블로그 데이터를 담고 있는 상태를 초기화 시켜줌

slider 구현 중 슬라이더 버튼 시 다른 사용자 카테고리가 보이는것이 아니라 원하는 동작으로 이동되지 않았지만 transition3d값에서 -을 넣어서 이를 해결